### PR TITLE
fix: incorrect code snippet opening in markdown

### DIFF
--- a/public/es/gentleman-programming-book-es.pdf:Zone.Identifier
+++ b/public/es/gentleman-programming-book-es.pdf:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://smallpdf.com/

--- a/public/gentleman-programming-book.pdf:Zone.Identifier
+++ b/public/gentleman-programming-book.pdf:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://smallpdf.com/

--- a/src/data/book/en/Chapter04_GoLang.mdx
+++ b/src/data/book/en/Chapter04_GoLang.mdx
@@ -273,7 +273,7 @@ func MyFunction(element ElementType) {
 
 MyFunction(exampleElement)
 ```
-```markdown
+
 Here you might think that we are working on the element "exampleElement", but it's quite the opposite. By default, Go will create a copy of the element itself to work with it, so the usage of "element" inside the function "MyFunction" is different from "exampleElement"... it's a copy.
 
 So if we want to work with the same element passed as a parameter to the function, a pointer must be used. Normally when we create a variable, we mistakenly say that we create a property that holds a value inside it, when in reality what we are doing is creating a memory space, containing a value inside it, and then creating a reference (pointer) to that memory space which is represented by the name we give to our property:

--- a/src/data/book/es/Chapter04_GoLang.mdx
+++ b/src/data/book/es/Chapter04_GoLang.mdx
@@ -274,7 +274,7 @@ func MiFuncion(elemento TipoElemento) {
 
 MiFuncion(ejemploElemento)
 ```
-```markdown
+
 Aquí podrías pensar que estamos trabajando en el elemento "ejemploElemento", pero es todo lo contrario. Por defecto, Go creará una copia del elemento mismo para trabajar con él, por lo que el uso de "elemento" dentro de la función "MiFuncion" es diferente de "ejemploElemento"... es una copia.
 
 Entonces, si queremos trabajar con el mismo elemento pasado como parámetro a la función, se debe usar un puntero. Normalmente, cuando creamos una variable, erróneamente decimos que creamos una propiedad que contiene un valor dentro de ella, cuando en realidad lo que estamos haciendo es crear un espacio de memoria que contiene un valor dentro de él, y luego creamos una referencia (puntero) a ese espacio de memoria que está representado por el nombre que damos a nuestra propiedad:


### PR DESCRIPTION
### Description
This pull request fixes the incorrect opening of a code snippet in the markdown documentation.

### Related Issue
Fixes #6 

### Changes Made
- **chore: remove problematic files for Windows users**. This is explained in the next section.
- **fix: Fixed the incorrect markdown code snippet opening** in the `Chapter04_GoLang.mdx` files.

### Additional Commit Context
As a Windows user myself, I encountered an issue while trying to commit the fix for the markdown issue. Specifically, I discovered that certain files (`public/es/gentleman-programming-book-es.pdf:Zone.Identifier` and `public/gentleman-programming-book.pdf:Zone.Identifier`) contain colons (":") in their names, which are invalid characters for Windows filesystems. This made it impossible for me to proceed with the commit without first removing these files from the repository.

In Windows, characters like colons are not supported in file names, leading to conflicts with Git operations. Therefore, removing these files is essential to enable contributions from Windows environments where such filenames are incompatible.

Additionally, these deleted files are metadata associated with the related PDF files, likely unintentionally left behind when the PDFs were downloaded. This metadata, represented by the `Zone.Identifier`, indicates the origin of the file and is not necessary for the proper functioning of the project.